### PR TITLE
views: add template folder to blueprint

### DIFF
--- a/invenio_saml/views.py
+++ b/invenio_saml/views.py
@@ -166,7 +166,12 @@ def sls(idp, auth):
 
 def create_blueprint(state, import_name):
     """Create the SSO SAML extension blueprint."""
-    bp = Blueprint("sso_saml", import_name, url_prefix=state.url_prefix)
+    bp = Blueprint(
+        "sso_saml",
+        import_name,
+        url_prefix=state.url_prefix,
+        template_folder="templates",
+    )
 
     bp.add_url_rule(state.metadata_url, endpoint="metadata", view_func=metadata)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,8 @@ def app_config(app_config):
         },
         "idp-url": {"settings_url": "https://test-idp.com/settings"},
     }
+    # Add template
+    app_config["OAUTHCLIENT_LOGIN_USER_TEMPLATE"] = "invenio_saml/login_user.html"
     return app_config
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -8,6 +8,7 @@
 
 import pytest
 from flask import url_for
+from flask_security import url_for_security
 from mock import patch
 
 
@@ -130,3 +131,11 @@ def test_metadata(appctx, base_client, metadata_response):
         res = client.get(metadata_url)
         assert res.status_code == 401
         assert res.json == ["bad error", "worst error", "Test reason"]
+
+
+def test_login(appctx, base_client):
+    """Test the SAML login template at least loads."""
+    client = base_client
+    res = client.get(url_for_security("login"))
+    assert res.status_code == 200
+    assert "Sign in with SAML" in res.text


### PR DESCRIPTION
* Adds missing template folder to blueprint to align with the docs in https://inveniordm.docs.cern.ch/customize/authentication/#show-the-login-button