### PR TITLE
docs: explicitly add python requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,7 @@ build:
   apt_packages:
     - libxml2-dev 
     - libxmlsec1-dev
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
* When using `.readthedocs.yaml`, it seems that this particular section
  needs to be present on the file, otherwise the `requirements.txt`
  file is ignored. (closes https://github.com/inveniosoftware/invenio-saml/issues/5)