### PR TITLE
Allow customizing the user lookup function in acs_handler_factory

### DIFF
--- a/invenio_saml/handlers.py
+++ b/invenio_saml/handlers.py
@@ -90,8 +90,8 @@ def default_sls_handler(auth, next_url):
 
 
 def acs_handler_factory(
-    remote_app, 
-    account_info=default_account_info, 
+    remote_app,
+    account_info=default_account_info,
     account_setup=default_account_setup,
     user_lookup=account_get_user,
 ):

--- a/invenio_saml/handlers.py
+++ b/invenio_saml/handlers.py
@@ -90,7 +90,10 @@ def default_sls_handler(auth, next_url):
 
 
 def acs_handler_factory(
-    remote_app, account_info=default_account_info, account_setup=default_account_setup
+    remote_app, 
+    account_info=default_account_info, 
+    account_setup=default_account_setup,
+    user_lookup=account_get_user,
 ):
     """Generate ACS handlers with an specific account info and setup functions.
 
@@ -127,6 +130,10 @@ def acs_handler_factory(
         corresponding IdP account information. Typically this means creating a
         new row under ``UserIdentity`` and maybe extending  ``g.identity``.
 
+    :param user_lookup: callable to retrieve any user whose information matches
+        what is returned by the `account_info` callable. This then returns a
+        User object if a match is present and None if no match is found.
+
     :return: function to be used as ACS handler
     """
 
@@ -146,7 +153,7 @@ def acs_handler_factory(
             current_app.logger.debug("Metadata extracted from IdP %s", _account_info)
             # TODO: signals?
 
-            user = account_get_user(_account_info)
+            user = user_lookup(_account_info)
 
             if user is None:
                 form = create_csrf_disabled_registrationform(remote_app)


### PR DESCRIPTION
Allow customizing the user lookup function in acs_handler_factory

### Description

This small change allows for customizing the logic that looks up users once their account info has been extracted from the SAML response. The factory function currently allows passing in custom callables to override the extraction of account info and the account setup logic. This change simply follows the same model to allow customization of the user lookup.

Our motivating use case is to allow matching users based on ORCID id as well as email address. This will help to ensure matching users are found when an InvenioRDM account has been created programmatically prior to the user's login. Instance-specific requirements like this would require writing and maintaining our own full acs handler at present. But the user lookup logic is already encapsulated in a separate function. So this change allows us to simply override that function with our own, leaving the logic in the default acs handler function itself untouched.  

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ X] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
