### PR TITLE
Trusted hosts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@
 Changes
 =======
 
+Version v3.0.0 (released 2026-04-17)
+
+- fix: use TRUSTED_HOSTS
+    BREAKING CHANGE: flask>=3.1.0 introduced a new configuration variable
+    ``TRUSTS_HOSTS`` and Invenio-App has already deprecated ``APP_ALLOWED_HOSTS``
+    usage since.
+
 Version v2.0.0 (released 2026-02-10)
 
 - tests: remove pinned packages from deps
@@ -23,7 +30,6 @@ Version v1.2.0 (released 2025-07-17)
 
 - i18n: pulled translations
 - changes: spacing typo
-
 
 Version 1.1.0 (release 2025-05-08)
 

--- a/invenio_saml/__init__.py
+++ b/invenio_saml/__init__.py
@@ -58,6 +58,6 @@ This is how you can use them:
 
 from .ext import InvenioSSOSAML
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = ("__version__", "InvenioSSOSAML")

--- a/invenio_saml/invenio_app.py
+++ b/invenio_saml/invenio_app.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019 Esteban J. Garcia Gabancho.
 # Copyright (C) 2019-2021 CERN.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2026 Paradigm Repositories.
 #
 # Invenio-SAML is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -25,7 +26,7 @@ def get_safe_redirect_target(arg="next", _target=None):
     for target in _target, request.args.get(arg), request.referrer:
         if target:
             redirect_uri = urisplit(target)
-            allowed_hosts = current_app.config.get("APP_ALLOWED_HOSTS", [])
+            allowed_hosts = current_app.config.get("TRUSTED_HOSTS", [])
             if redirect_uri.host in allowed_hosts:
                 return target
             elif redirect_uri.path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ class MockManifestLoader(JinjaManifestLoader):
 @pytest.fixture(scope="module")
 def app_config(app_config):
     """Customize application configuration."""
-    app_config["APP_ALLOWED_HOSTS"] = [
+    app_config["TRUSTED_HOSTS"] = [
         "localhost",
         "example.com",
         "tests.com:5000",


### PR DESCRIPTION
flask>=3.1.0 introduced a new configuration variable `TRUSTS_HOSTS` and Invenio-App has already deprecated `APP_ALLOWED_HOSTS` usage since.